### PR TITLE
chore: Update bullseye to bookworm

### DIFF
--- a/Dockerfile.deepnote
+++ b/Dockerfile.deepnote
@@ -14,5 +14,5 @@ RUN apt update && apt install -y --no-install-recommends \
 
 RUN cd /tmp && git clone -b deepnote-v2.1 --single-branch --depth 1 https://github.com/deepnote/aws-cli && \
   cd /tmp/aws-cli && \
-  pip install .
+  pip install . --break-system-packages
 

--- a/Dockerfile.deepnote
+++ b/Dockerfile.deepnote
@@ -1,18 +1,18 @@
-FROM node:18.20.1-bullseye-slim
+FROM node:22.24.0-bookworm-slim
 
 ENV AWSCLI_VERSION=2.10.1
 
 RUN apt update && apt install -y --no-install-recommends \
-    curl ca-certificates bash \
-    postgresql-client \
-    # Needed to install awscli
-    unzip \
-    git \
-    patch \
-    python3-pip \
-    && rm -rf /var/lib/apt/lists/*
+  curl ca-certificates bash \
+  postgresql-client \
+  # Needed to install awscli
+  unzip \
+  git \
+  patch \
+  python3-pip \
+  && rm -rf /var/lib/apt/lists/*
 
 RUN cd /tmp && git clone -b deepnote-v2.1 --single-branch --depth 1 https://github.com/deepnote/aws-cli && \
-    cd /tmp/aws-cli && \
-    pip install .
+  cd /tmp/aws-cli && \
+  pip install .
 

--- a/Dockerfile.deepnote
+++ b/Dockerfile.deepnote
@@ -1,4 +1,4 @@
-FROM node:22.24.0-bookworm-slim
+FROM node:22.14.0-bookworm-slim
 
 ENV AWSCLI_VERSION=2.10.1
 


### PR DESCRIPTION
I would like to change base image to bookworm and push it under `deepnote/aws-cli:2.13.37-bookworm` tag. Bookworm comes with python 3.11, which is a reason for this change as well since we'd like to update deepnote base image to bookworm.